### PR TITLE
[xs][bugfix] quick return on not budgetExceeded or not grown

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -30,7 +30,7 @@ exports.handleBillingAlert = onMessagePublished(
 
     const budgetExceeded = eventData.costAmount >= eventData.budgetAmount;
     if (
-      !budgetExceeded &&
+      !budgetExceeded ||
       eventData.costAmount - lastReportedCost < MIN_COST_DIFF_FOR_ALERT
     )
       return;


### PR DESCRIPTION
I believe there should be || instead of &&
Rationale:
we should not progress if the budget was not exceeded OR if last time was exceeded but it didn't grow since then